### PR TITLE
Use version 0.3.0-dev of Jubako

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,8 +490,7 @@ dependencies = [
 
 [[package]]
 name = "jubako"
-version = "0.2.1"
-source = "git+https://github.com/jubako/jubako.git#36ce8c375aa289e00e6c7843781d421fb3f36a92"
+version = "0.3.0-dev"
 dependencies = [
  "blake3",
  "clap",
@@ -523,7 +522,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libwaj"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ascii",
  "blake3",
@@ -962,7 +961,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "waj"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/jubako/waj"
 license = "MIT"
 
 [workspace.dependencies]
-jbk = { git = "https://github.com/jubako/jubako.git", package = "jubako", version = "0.2.1" }
+jbk = { git = "https://github.com/jubako/jubako.git", package = "jubako", version = "0.3.0-dev" }
 
 [package]
 name = "waj"

--- a/libwaj/src/common/properties.rs
+++ b/libwaj/src/common/properties.rs
@@ -1,3 +1,5 @@
+use jbk::reader::VariantPart;
+
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
 pub enum Property {
     Path,
@@ -35,19 +37,23 @@ impl AllProperties {
         value_storage: &jbk::reader::ValueStorage,
     ) -> jbk::Result<Self> {
         let layout = store.layout();
-        let (variant_offset, variants, variants_map) = layout.variant_part.as_ref().unwrap();
+        let VariantPart {
+            variant_id_offset,
+            variants,
+            names,
+        } = layout.variant_part.as_ref().unwrap();
         assert_eq!(variants.len(), 2);
         let path_property = (&layout.common["path"], value_storage).try_into()?;
-        let variant_id_property = jbk::reader::builder::VariantIdProperty::new(*variant_offset);
+        let variant_id_property = jbk::reader::builder::VariantIdProperty::new(*variant_id_offset);
         let content_mimetype_property = (
-            &variants[variants_map["content"] as usize]["mimetype"],
+            &variants[names["content"] as usize]["mimetype"],
             value_storage,
         )
             .try_into()?;
         let content_address_property =
-            (&variants[variants_map["content"] as usize]["content"]).try_into()?;
+            (&variants[names["content"] as usize]["content"]).try_into()?;
         let redirect_target_property = (
-            &variants[variants_map["redirect"] as usize]["target"],
+            &variants[names["redirect"] as usize]["target"],
             value_storage,
         )
             .try_into()?;


### PR DESCRIPTION
Bigger change is to correctly handle missing pack.
    
This add complexity as we have 3 "cases":
 - with_content==false (etag, head) where we have to not return a content, whatever the other cases.
 - Missing pack. We have to generate pseudo content when pack is missing. (but not for 404)
 - 404 when we have to search for 404 content in the waj if url not found (but still impacted by other cases)

On top of that, we have cache header:
 - We have to set header as content will not change between request (Only if waj change, so etag change too).
 - Even for 404 (entry will not suddenly appears in Waj, and 404 content will not change)
 - NOT for missing pack as a change on server side (content pack available) may make us return a new request without etag change.