### PR TITLE
Include git tag in `--version` output.

### DIFF
--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -73,6 +73,8 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        fetch-tags: true
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: Publish
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +441,26 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "hashbrown"
@@ -959,6 +999,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,7 +1027,9 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
+ "const_format",
  "env_logger",
+ "git-version",
  "human-panic",
  "indicatif",
  "jubako",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.0.32", features = ["derive"] }
+clap = { version = "4.0.32", features = ["derive", "cargo"] }
 clap_mangen = "0.2.20"
 clap_complete = "4.5.0"
 human-panic = "2.0.2"
@@ -36,3 +36,5 @@ env_logger = "0.11.5"
 anyhow = "1.0.75"
 log = "0.4.20"
 jbk.workspace = true
+const_format = "0.2.33"
+git-version = "0.3.9"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,14 @@ use log::error;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+const VERSION: &str = const_format::formatcp!(
+    "{} (git:{})",
+    clap::crate_version!(),
+    git_version::git_version!(args = ["--dirty=*", "--tags", "--always"])
+);
+
 #[derive(Parser)]
-#[command(name = "waj", author, version, about, long_about=None)]
+#[command(name = "waj", author, version, long_version=VERSION, about, long_about=None)]
 struct Cli {
     /// Set verbose level. Can be specify several times to augment verbose level.
     #[arg(short, long, action=clap::ArgAction::Count, global=true)]


### PR DESCRIPTION
Short version (`-V`) is unchanged and displays declared version only.