### PR TITLE
Adapt to new jbk api about variant and property name.

### DIFF
--- a/libwaj/src/common/entry_type.rs
+++ b/libwaj/src/common/entry_type.rs
@@ -1,33 +1,9 @@
-use crate::error::WajFormatError;
-
-#[repr(u8)]
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub enum EntryType {
-    Content = 0,
-    Redirect = 1,
-}
-
-impl TryFrom<jbk::VariantIdx> for EntryType {
-    type Error = WajFormatError;
-    fn try_from(id: jbk::VariantIdx) -> Result<Self, Self::Error> {
-        match id.into_u8() {
-            0 => Ok(Self::Content),
-            1 => Ok(Self::Redirect),
-            _ => Err(WajFormatError("Invalid variant id")),
-        }
+jbk::variants! {
+    EntryType {
+        Content => "content",
+        Redirect => "redirect"
     }
 }
-
-impl ToString for EntryType {
-    fn to_string(&self) -> String {
-        String::from(match self {
-            EntryType::Content => "content",
-            EntryType::Redirect => "redirect",
-        })
-    }
-}
-
-impl jbk::creator::VariantName for EntryType {}
 
 impl From<EntryType> for jbk::VariantIdx {
     fn from(t: EntryType) -> Self {


### PR DESCRIPTION
Jbk simplify a bit the definition of variant, properties and builder with the use of macro.

In the same time, it fixes an issue about wrong parsing of variant type (at least, not taking into account the variant name mapping).