### PR TITLE
Move to last (dev) version of Jubako.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -588,13 +594,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -655,7 +672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -669,6 +686,15 @@ dependencies = [
  "unicode-width",
  "unit-prefix",
  "web-time",
+]
+
+[[package]]
+name = "internment"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636d4b0f6a39fd684effe2a73f5310df16a3fa7954c26d36833e98f44d1977a2"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -729,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "jubako"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "blake3",
  "camino",
@@ -789,6 +815,7 @@ dependencies = [
  "blake3",
  "fxhash",
  "http-range-header",
+ "internment",
  "jubako",
  "libc",
  "log",
@@ -834,7 +861,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ homepage = "https://github.com/jubako/waj"
 license = "MIT"
 
 [workspace.dependencies]
-jbk = { git = "https://github.com/jubako/jubako.git", package = "jubako", features = ["clap"], version = "0.4.0" }
+jbk = { git = "https://github.com/jubako/jubako.git", package = "jubako", features = ["clap"], version = "0.5.0-dev" }

--- a/libwaj/Cargo.toml
+++ b/libwaj/Cargo.toml
@@ -31,6 +31,7 @@ ascii = "1.1.0"
 signal-hook = "0.3.17"
 thiserror = "2.0.9"
 http-range-header = "0.4.2"
+internment = "0.8.6"
 
 [dev-dependencies]
 rustest = { version = "0.3.1" }

--- a/libwaj/src/create/entry.rs
+++ b/libwaj/src/create/entry.rs
@@ -1,88 +1,60 @@
+use internment::Intern;
+use jbk::{SmallBytes, Value};
+
 use crate::common::*;
 
-pub struct Path1 {
-    value_id: jbk::creator::ValueHandle,
-    prefix: u8,
-    size: u16,
-}
-static_assertions::assert_eq_size!(Path1, [u8; 24]);
-
-impl Path1 {
-    pub fn new(mut path: Vec<u8>, value_store: &jbk::creator::StoreHandle) -> Self {
-        //        println!("Add path {path:?}");
-        let size = path.len() as u16;
-        let prefix = if size == 0 { 0 } else { path.remove(0) };
-        let value_id = value_store.add_value(path);
-        Self {
-            prefix,
-            size,
-            value_id,
-        }
-    }
-}
-
+#[derive(Debug)]
 pub struct Content {
-    mimetype: jbk::creator::ValueHandle,
-    content_id: jbk::ContentIdx,
-    pack_id: jbk::PackId,
+    mimetype: Intern<SmallBytes>,
+    content: jbk::ContentAddress,
 }
-static_assertions::assert_eq_size!(Content, [u8; 24]);
+static_assertions::assert_eq_size!(Content, [u8; 16]);
 
+#[derive(Debug)]
 pub struct Entry {
-    idx: jbk::Vow<jbk::EntryIdx>,
     // The three path_* are technically a Path1.
     // But extract the three fields from the Path1 allow compiler to
     // reorganise the fields and reduce the structure size.
-    path_value_id: jbk::creator::ValueHandle,
-    path_prefix: u8,
-    path_size: u16,
-
+    pub(crate) path: SmallBytes,
     kind: EntryKind,
 }
 
+#[derive(Debug)]
 pub enum EntryKind {
     Content(Content),
-    Redirect(Path1),
+    Redirect(SmallBytes),
 }
-static_assertions::assert_eq_size!(Entry, [u8; 64]);
+static_assertions::assert_eq_size!(Entry, [u8; 56]);
 
 impl Entry {
     pub fn new_content(
-        path: Path1,
-        mimetype: jbk::creator::ValueHandle,
+        path: SmallBytes,
+        mimetype: SmallBytes,
         content: jbk::ContentAddress,
     ) -> Self {
         Self {
-            idx: jbk::Vow::new(0.into()),
-            path_value_id: path.value_id,
-            path_prefix: path.prefix,
-            path_size: path.size,
+            path,
             kind: EntryKind::Content(Content {
-                mimetype,
-                content_id: content.content_id,
-                pack_id: content.pack_id,
+                mimetype: Intern::new(mimetype),
+                content,
             }),
         }
     }
 
-    pub fn new_redirect(path: Path1, target: Path1) -> Self {
+    pub fn new_redirect(path: SmallBytes, target: SmallBytes) -> Self {
         Self {
-            idx: jbk::Vow::new(0.into()),
-            path_value_id: path.value_id,
-            path_prefix: path.prefix,
-            path_size: path.size,
-
+            path,
             kind: EntryKind::Redirect(target),
         }
     }
 }
 
 impl jbk::creator::EntryTrait<Property, EntryType> for Entry {
-    fn variant_name(&self) -> Option<jbk::MayRef<'_, EntryType>> {
-        Some(jbk::MayRef::Owned(match self.kind {
+    fn variant_name(&self) -> Option<EntryType> {
+        Some(match self.kind {
             EntryKind::Content(_) => EntryType::Content,
             EntryKind::Redirect(_) => EntryType::Redirect,
-        }))
+        })
     }
 
     fn value_count(&self) -> jbk::PropertyCount {
@@ -92,70 +64,28 @@ impl jbk::creator::EntryTrait<Property, EntryType> for Entry {
         }
     }
 
-    fn set_idx(&mut self, idx: jbk::EntryIdx) {
-        self.idx.fulfil(idx)
-    }
-
-    fn get_idx(&self) -> jbk::Bound<jbk::EntryIdx> {
-        self.idx.bind()
-    }
-
-    fn value(&self, name: &Property) -> jbk::MayRef<'_, jbk::creator::Value> {
-        jbk::MayRef::Owned(match name {
-            Property::Path => jbk::creator::Value::Array1(Box::new(jbk::creator::ArrayS::<1> {
-                data: [self.path_prefix],
-                value_id: self.path_value_id.clone_get(),
-                size: self.path_size as usize,
-            })),
+    fn value(&self, name: &Property) -> Value {
+        match name {
+            Property::Path => Value::Array(self.path.clone()),
             Property::Mimetype => {
                 if let EntryKind::Content(content) = &self.kind {
-                    jbk::creator::Value::IndirectArray(Box::new(content.mimetype.clone_get()))
+                    Value::Array((*content.mimetype).clone())
                 } else {
                     unreachable!()
                 }
             }
             Property::Content => {
                 if let EntryKind::Content(content) = &self.kind {
-                    jbk::creator::Value::Content(jbk::ContentAddress::new(
-                        content.pack_id,
-                        content.content_id,
-                    ))
+                    Value::Content(content.content)
                 } else {
                     unreachable!()
                 }
             }
             Property::Target => {
                 if let EntryKind::Redirect(target) = &self.kind {
-                    jbk::creator::Value::Array1(Box::new(jbk::creator::ArrayS::<1> {
-                        data: [target.prefix],
-                        value_id: target.value_id.clone_get(),
-                        size: target.size as usize,
-                    }))
+                    Value::Array(target.clone())
                 } else {
                     unreachable!()
-                }
-            }
-        })
-    }
-}
-
-impl jbk::creator::FullEntryTrait<Property, EntryType> for Entry {
-    fn compare<'i, I>(&self, _sort_keys: &'i I, other: &Self) -> std::cmp::Ordering
-    where
-        I: IntoIterator<Item = &'i Property> + Copy,
-    {
-        use std::cmp;
-        //let mut iter = sort_keys.into_iter();
-        //assert_eq!(iter.next(), Some(&Property::Path));
-        //assert_eq!(iter.next(), None);
-        match self.path_prefix.cmp(&other.path_prefix) {
-            cmp::Ordering::Less => cmp::Ordering::Less,
-            cmp::Ordering::Greater => cmp::Ordering::Greater,
-            cmp::Ordering::Equal => {
-                match self.path_value_id.get().cmp(&other.path_value_id.get()) {
-                    cmp::Ordering::Less => cmp::Ordering::Less,
-                    cmp::Ordering::Greater => cmp::Ordering::Greater,
-                    cmp::Ordering::Equal => self.path_size.cmp(&other.path_size),
                 }
             }
         }


### PR DESCRIPTION
Now Jubako entry store creator takes an iterator on entries. The values of the entries will be add by jubako itself to value stores and such, so no need to handle that.

We use the crate internment to store the mimetypes as they are mostly duplicated and interning them avoid unecessary copies.